### PR TITLE
script to run local postgres docker instance

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,5 +8,6 @@
     "org_name": "Lightmatter",
     "description": "A short description of the project.",
     "domain_name": "example.com",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "database_name": "genericapp"
 }

--- a/{{cookiecutter.repo_name}}/scripts/restart-postgres-dev-docker.sh
+++ b/{{cookiecutter.repo_name}}/scripts/restart-postgres-dev-docker.sh
@@ -1,13 +1,10 @@
 # invocation:
 #
-# replace $PGPASSWORD with actual dev password:
+# Make sure PGPORT, PGUSER, PGHOST, and PGPASSWORD are set correctly inside
+# .env, and then:
 #
-# PGPORT=5432 PGUSER=postgres PGHOST=localhost PGPASSWORD=foo bash restart-postgres-dev-docker.sh
-#
-# alternately:
-#
-# export PGPORT=5432 PGUSER=postgres PGHOST=localhost PGPASSWORD=foo;
-#
+# set -a;
+# source .env;
 # bash restart-postgres-dev-docker.sh;
 
 IMAGE='postgres:latest'

--- a/{{cookiecutter.repo_name}}/scripts/restart-postgres-dev-docker.sh
+++ b/{{cookiecutter.repo_name}}/scripts/restart-postgres-dev-docker.sh
@@ -1,0 +1,20 @@
+# invocation:
+#
+# replace $PGPASSWORD with actual dev password:
+#
+# PGPORT=5432 PGUSER=postgres PGHOST=localhost PGPASSWORD=foo bash restart-postgres-dev-docker.sh
+#
+# alternately:
+#
+# export PGPORT=5432 PGUSER=postgres PGHOST=localhost PGPASSWORD=foo;
+#
+# bash restart-postgres-dev-docker.sh;
+
+IMAGE='postgres:latest'
+CONTAINER='{{cookiecutter.database_name}}-postgres-container';
+
+docker stop $CONTAINER;
+docker rm $CONTAINER;
+docker rmi $IMAGE;
+
+docker run -p $PGPORT:5432 --name $CONTAINER -e POSTGRES_PASSWORD=$PGPASSWORD -d postgres;


### PR DESCRIPTION
Optional but helpful script for local development. If you use a dockerized postgres instance, you don't need to install postgres globally on your machine and you can keep db config separate between different projects.