### PR TITLE
Revert "Bump webpack-bundle-analyzer from 2.13.1 to 3.6.0 in /{{cookiecutter.repo_name}}"

### DIFF
--- a/{{cookiecutter.repo_name}}/package.json
+++ b/{{cookiecutter.repo_name}}/package.json
@@ -35,7 +35,7 @@
     "lint-staged": "^9.2.0",
     "lynt": "^0.5.5",
     "prettier": "^1.18.2",
-    "webpack-bundle-analyzer": "^3.6.0",
+    "webpack-bundle-analyzer": "^2.11.1",
     "webpack-dev-server": "^3.1.10"
   },
   "dependencies": {


### PR DESCRIPTION
Reverts Lightmatter/generic-django-conf#82