### PR TITLE
Empty quotes in API_BASE_URL break API calls

### DIFF
--- a/{{cookiecutter.repo_name}}/docker-compose.yml
+++ b/{{cookiecutter.repo_name}}/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - SECRET_KEY="foobar"
       - DATABASE_URL=psql://{{cookiecutter.repo_name}}:{{cookiecutter.repo_name}}@db/{{cookiecutter.repo_name}}
       - DJANGO_SETTINGS_MODULE={{cookiecutter.repo_name}}.{{cookiecutter.repo_name}}.settings.local
-      - API_BASE_URL=""
+      - API_BASE_URL=
       - PORT=4000
       - ENVIRONMENT=local
     volumes:


### PR DESCRIPTION
API_BASE_URL gets set to literal empty quotes, which puts `%22%22` in API URLs.
