### PR TITLE
fixing issue where prefixes don't pass through

### DIFF
--- a/{{cookiecutter.repo_name}}/src/components/router/Link.jsx
+++ b/{{cookiecutter.repo_name}}/src/components/router/Link.jsx
@@ -9,11 +9,11 @@ import isServer from '{{cookiecutter.repo_name}}/src/util/isServer';
 import { Button } from '@material-ui/core';
 
 const NextComposed = React.forwardRef(function NextComposed(
-  { as, href, ...other },
+  { as, href, prefetch, ...other },
   ref
 ) {
   return (
-    <NextLink href={href} as={as}>
+    <NextLink href={href} as={as} prefetch={prefetch}>
       <a ref={ref} {...other} />
     </NextLink>
   );


### PR DESCRIPTION
Had an issue where a list view of items was prefetching EVERY item on the list. Realized Link prefetches by default and then realized our implementation didn't pass through to the right spot