### PR TITLE
changes to install script for nvm, and pyenv virtualenvwrapper

### DIFF
--- a/scripts/mac_intel_install.sh
+++ b/scripts/mac_intel_install.sh
@@ -25,6 +25,9 @@ brew install nvm
 echo "${prefix}Installing pyenv"
 brew install pyenv
 
+echo "${prefix}Installing pyenv-virtualenvwrapper"
+brew install pyenv-virtualenvwrapper
+
 echo "${prefix}Installing git"
 brew install git
 
@@ -45,10 +48,13 @@ brew install watchman
 echo "${prefix}Adding pyenv, direnv, poetry and path config to .zshrc"
 
 echo "# START LM 3.0 Configuration" >> ~/.zshrc
-
+echo "NVM_DIR=~/.nvm" >> ~/.zshrc
+echo "eval \"source \$(brew --prefix nvm)/nvm.sh\"" >> ~/.zshrc
 echo "eval \"\$(pyenv init --path)\"" >> ~/.zshrc
 echo "eval \"\$(pyenv init -)\"" >> ~/.zshrc
 echo "eval \"\$(direnv hook zsh)\"" >> ~/.zshrc
+echo "eval \"source \$(pyenv which virtualenvwrapper.sh)\"" >> ~/.zshrc
+echo "export WORKON_HOME=\"~/.virtualenvs\"" >> ~/.zshrc
 echo "export PATH=\"\$HOME/.poetry/bin:\$PATH\"" >> ~/.zshrc
 
 echo "${prefix}Reloading zsh"

--- a/scripts/mac_intel_install.sh
+++ b/scripts/mac_intel_install.sh
@@ -19,6 +19,9 @@ fi
 echo "${prefix}Installing node"
 brew install node
 
+echo "${prefix}Installing yarn"
+npm install yarn
+
 echo "${prefix}Installing node version manager (nvm)"
 brew install nvm
 


### PR DESCRIPTION
These are just things I ended up adding as I needed to set up specifically for HLE as well. Not sure if they're worth actually putting in or if we should have a separate branch like 'maintenance / legacy setup' for specifically having this stuff in there or if it should be added generally. 

It deals with: 
installing yarn
setting up pyenv virtualenvwrapper and workon (could potentially add the postactivate and postdeactivate to this as well) 
setting up nvm so it can be run immediately (this is unrelated to legacy but for me i had to add the nvm lines before the script could move on and do the node version installation)
