### PR TITLE
Add htmx view to template

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/util/util.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/util/util.py
@@ -3,7 +3,24 @@ import re
 import time
 
 from django.utils.deconstruct import deconstructible
+from django.views.generic.base import TemplateView
 
+
+class HtmxView(TemplateView):
+    """
+    This view will act as a normal template view, but will allow you to return a status code
+    in the .as_view function. This is useful for Htmx since various status codes are used
+    with views to signal that something has changed. E.g. returning 286 can turn off a
+    /get automatically polling.
+
+    Sample, inside urlpatterns:
+    path(r"news/", HtmxView.as_view(template_name="news.html", status=286)),
+    """
+    status = 200
+
+    def render_to_response(self, context, **response_kwargs):
+        response_kwargs["status"] = self.status
+        return super(TemplateView, self).render_to_response(context, **response_kwargs)
 
 @deconstructible
 class file_url:  # NOQA


### PR DESCRIPTION
This adds a means to use `Htmxview.as_view(...)` instead of the regular TemplateView. The purpose of this is because of items like [polling](https://htmx.org/docs/#polling) which allow you to return a separate response to turn off the polling. 