### PR TITLE
Add ngrok to allowed hosts

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings/local.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings/local.py
@@ -5,7 +5,7 @@ from .base import env
 # GENERAL
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
+ALLOWED_HOSTS = ["localhost", "127.0.0.1", ".ngrok.io"]
 
 # CACHES
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This allows devs to use ngrok for local testing. I used this in my last project for testing webhook views.