### PR TITLE
Update to Vite 3.x

### DIFF
--- a/{{cookiecutter.repo_name}}/package.json
+++ b/{{cookiecutter.repo_name}}/package.json
@@ -25,7 +25,7 @@
     "stylelint-config-standard-scss": "^3.0.0",
     "tailwindcss": "^3.0.24",
     "typescript": "^4.6.4",
-    "vite": "^2.9.6"
+    "vite": "^3.1.3"
   },
   "dependencies": {
     "@alpinejs/focus": "^3.10.2",

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings/base.py
@@ -163,6 +163,7 @@ STATICFILES_FINDERS = [
 
 DJANGO_VITE_ASSETS_PATH = root.path("static")
 DJANGO_VITE_DEV_MODE = DEBUG
+DJANGO_VITE_DEV_SERVER_PORT = 5173
 
 # MEDIA
 # ------------------------------------------------------------------------------
@@ -301,7 +302,7 @@ ACCOUNT_AUTHENTICATION_METHOD = "email"
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_EMAIL_VERIFICATION = "none"
 ACCOUNT_SIGNUP_EMAIL_ENTER_TWICE = True
-ACCOUNT_ADAPTER = '{{cookiecutter.repo_name}}.user.adapter.HTMXAccountAdapter'
+ACCOUNT_ADAPTER = "{{cookiecutter.repo_name}}.user.adapter.HTMXAccountAdapter"
 
 # https://django-allauth.readthedocs.io/en/latest/forms.html#account-forms
 ACCOUNT_FORMS = {


### PR DESCRIPTION
This updates from Vite 2.x to 3.x and changes the port setting for `django-vite`.

https://github.com/MrBin99/django-vite/issues/51